### PR TITLE
feat: Add reverse property and inject scrollController

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,6 +23,13 @@ class MyApp extends StatelessWidget {
                   trailing: const Icon(Icons.chevron_right),
                 ),
                 ListTile(
+                  title: const Text('Reversed Infinite List'),
+                  onTap: () {
+                    Navigator.of(context).push(_ReversedInfiniteList.route());
+                  },
+                  trailing: const Icon(Icons.chevron_right),
+                ),
+                ListTile(
                   title: const Text('Custom Infinite List'),
                   onTap: () {
                     Navigator.of(context).push(_CustomInfiniteList.route());
@@ -52,6 +59,26 @@ class _DefaultInfiniteList extends StatelessWidget {
         builder: InfiniteListBuilder<String>(
           success: (context, item) => ListTile(title: Text(item)),
         ),
+      ),
+    );
+  }
+}
+
+class _ReversedInfiniteList extends StatelessWidget {
+  static Route route() {
+    return MaterialPageRoute(builder: (_) => _ReversedInfiniteList());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reversed Infinite List')),
+      body: InfiniteList<String>(
+        itemLoader: _itemLoader,
+        builder: InfiniteListBuilder<String>(
+          success: (context, item) => ListTile(title: Text(item)),
+        ),
+        reverse: true,
       ),
     );
   }

--- a/lib/very_good_infinite_list.dart
+++ b/lib/very_good_infinite_list.dart
@@ -233,6 +233,16 @@ class _InfiniteListState<T> extends State<InfiniteList<T>> {
   }
 
   @override
+  void didUpdateWidget(covariant InfiniteList<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget._scrollController != oldWidget._scrollController) {
+      _scrollController.removeListener(_onScroll);
+      _scrollController = widget._scrollController ?? ScrollController()
+        ..addListener(_onScroll);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
       valueListenable: _controller,

--- a/lib/very_good_infinite_list.dart
+++ b/lib/very_good_infinite_list.dart
@@ -115,12 +115,15 @@ class InfiniteList<T> extends StatefulWidget {
     WidgetBuilder bottomLoader,
     ErrorBuilder errorLoader,
     this.debounceDuration,
+    this.reverse = false,
     this.onError,
+    ScrollController scrollController,
     double scrollOffsetThreshold,
   })  : assert(itemLoader != null),
         assert(builder != null),
         _bottomLoader = bottomLoader,
         _errorLoader = errorLoader,
+        _scrollController = scrollController,
         _scrollOffsetThreshold =
             scrollOffsetThreshold ?? _kScrollOffsetThreshold,
         super(key: key);
@@ -162,9 +165,25 @@ class InfiniteList<T> extends StatefulWidget {
   /// {@macro on_error}
   final OnError onError;
 
+  final ScrollController _scrollController;
+
   /// Debounce duration for the [itemLoader].
   /// Defaults to `const Duration(milliseconds: 100)`.
   final Duration debounceDuration;
+
+  /// Whether the scroll view scrolls in the reading direction.
+  ///
+  /// For example, if the reading direction is left-to-right and
+  /// scroll direction is horizontal, then the scroll view scrolls from
+  /// left to right when [reverse] is false and from right to left when
+  /// [reverse] is true.
+  ///
+  /// Similarly, if scroll direction is vertical, then the scroll view
+  /// scrolls from top to bottom when [reverse] is false and from bottom to top
+  /// when [reverse] is true.
+  ///
+  /// Defaults to false.
+  final bool reverse;
 
   final double _scrollOffsetThreshold;
 
@@ -173,7 +192,7 @@ class InfiniteList<T> extends StatefulWidget {
 }
 
 class _InfiniteListState<T> extends State<InfiniteList<T>> {
-  final _scrollController = ScrollController();
+  ScrollController _scrollController;
   _ListController<T> _controller;
   _Debouncer _debouncer;
 
@@ -193,7 +212,8 @@ class _InfiniteListState<T> extends State<InfiniteList<T>> {
     super.initState();
     _controller = _ListController<T>(widget.itemLoader);
     _debouncer = _Debouncer(delay: widget.debounceDuration);
-    _scrollController.addListener(_onScroll);
+    _scrollController = widget._scrollController ?? ScrollController()
+      ..addListener(_onScroll);
     _controller
       ..addListener(_onListStateChanged)
       ..fetch();
@@ -243,6 +263,7 @@ class _InfiniteListState<T> extends State<InfiniteList<T>> {
         }
 
         return ListView.builder(
+          reverse: widget.reverse,
           controller: _scrollController,
           itemCount: itemCount,
           itemBuilder: (context, index) {
@@ -328,6 +349,7 @@ extension on _ListStatus {
 
 class _ListException implements Exception {
   const _ListException(this.value);
+
   final Object value;
 
   static const none = _ListException(null);

--- a/lib/very_good_infinite_list.dart
+++ b/lib/very_good_infinite_list.dart
@@ -225,9 +225,10 @@ class _InfiniteListState<T> extends State<InfiniteList<T>> {
     _controller
       ..removeListener(_onListStateChanged)
       ..dispose();
-    _scrollController
-      ..removeListener(_onScroll)
-      ..dispose();
+    _scrollController.removeListener(_onScroll);
+    if (widget._scrollController == null) {
+      _scrollController.dispose();
+    }
     super.dispose();
   }
 

--- a/test/very_good_infinite_list_test.dart
+++ b/test/very_good_infinite_list_test.dart
@@ -32,7 +32,9 @@ void main() {
         itemLoaderCallCount++;
         return List.generate(15, (i) => i);
       };
-      var scrollController = ScrollController();
+      final oldController = ScrollController();
+      final newController = ScrollController();
+      var scrollController = oldController;
 
       await tester.pumpApp(
         StatefulBuilder(
@@ -54,7 +56,7 @@ void main() {
                 child: const Icon(Icons.add),
                 onPressed: () {
                   setState(() {
-                    scrollController = ScrollController();
+                    scrollController = newController;
                   });
                 },
               ),
@@ -65,19 +67,26 @@ void main() {
 
       await tester.pump();
 
-      await tester.drag(
-        find.byKey(const Key('__item_9__')),
-        const Offset(0, -500),
-      );
-
       expect(itemLoaderCallCount, equals(1));
 
-      expect(find.byKey(const Key('__item_9__')), findsOneWidget);
+      await tester.drag(
+        find.byKey(const Key('__item_0__')),
+        const Offset(0, -100),
+      );
+
+      await tester.pump();
+      expect(find.byKey(const Key('__item_0__')), findsNothing);
       await tester.tap(find.byType(FloatingActionButton));
-      await tester.pumpAndSettle();
+
+      await tester.pump();
+
+      expect(oldController.hasClients, isFalse);
+      expect(newController.hasClients, isTrue);
+
+      newController.jumpTo(0);
+      await tester.pump();
 
       expect(find.byKey(const Key('__item_0__')), findsOneWidget);
-      expect(find.byKey(const Key('__item_9__')), findsNothing);
       expect(itemLoaderCallCount, equals(1));
     });
 

--- a/test/very_good_infinite_list_test.dart
+++ b/test/very_good_infinite_list_test.dart
@@ -90,6 +90,43 @@ void main() {
       expect(itemLoaderCallCount, equals(1));
     });
 
+    testWidgets('reverse updates list view', (tester) async {
+      final itemLoader = (int limit, {int start}) async {
+        return List.generate(15, (i) => i);
+      };
+
+      await tester.pumpApp(
+        InfiniteList(
+          reverse: true,
+          itemLoader: itemLoader,
+          builder: InfiniteListBuilder(success: (_, __) => const SizedBox()),
+        ),
+      );
+
+      await tester.pump();
+
+      final listView = tester.widget<ListView>(find.byType(ListView));
+      expect(listView.reverse, isTrue);
+    });
+
+    testWidgets('list view is not reversed by default', (tester) async {
+      final itemLoader = (int limit, {int start}) async {
+        return List.generate(15, (i) => i);
+      };
+
+      await tester.pumpApp(
+        InfiniteList(
+          itemLoader: itemLoader,
+          builder: InfiniteListBuilder(success: (_, __) => const SizedBox()),
+        ),
+      );
+
+      await tester.pump();
+
+      final listView = tester.widget<ListView>(find.byType(ListView));
+      expect(listView.reverse, isFalse);
+    });
+
     testWidgets('invokes itemLoader immediately', (tester) async {
       var itemLoaderCallCount = 0;
       final itemLoader = (int limit, {int start}) {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

- Add `reverse` property
- Inject scroll controller (Allows widgets such as `DraggableScrollableSheet` to pass in a `ScrollController`

<img width="518" alt="Screen Shot 2021-02-16 at 8 59 57 PM" src="https://user-images.githubusercontent.com/3614291/108145777-ffde5480-7099-11eb-96d8-cddc82435146.png">


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
