### PR TITLE
fix: WidgetsBinding null-aware operation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,4 +7,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
-      flutter_version: 2.10.1
+      flutter_version: 3.0.0

--- a/lib/very_good_infinite_list.dart
+++ b/lib/very_good_infinite_list.dart
@@ -179,7 +179,7 @@ class InfiniteListState extends State<InfiniteList> {
     super.initState();
     _debounce = CallbackDebouncer(widget.debounceDuration);
     _initScrollController();
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       _attemptFetch();
     });
   }
@@ -194,7 +194,7 @@ class InfiniteListState extends State<InfiniteList> {
 
     if (widget.itemCount != oldWidget.itemCount ||
         widget.hasReachedMax != oldWidget.hasReachedMax) {
-      WidgetsBinding.instance?.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         _attemptFetch();
       });
     }


### PR DESCRIPTION
## Description

Fix Flutter 3 warnings : 
```
: Warning: Operand of null-aware operation '?.' has type 'WidgetsBinding' which excludes null.
../…/lib/very_good_infinite_list.dart:182
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../../../flutter/packages/flutter/lib/src/widgets/binding.dart').
package:flutter/…/widgets/binding.dart:1
    WidgetsBinding.instance?.addPostFrameCallback((_) {
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
