### PR TITLE
fix: remove need for an extra pull

### DIFF
--- a/lib/src/defaults.dart
+++ b/lib/src/defaults.dart
@@ -20,8 +20,5 @@ Widget defaultInfiniteListErrorBuilder(BuildContext buildContext) {
   );
 }
 
-/// Default value to [InfiniteList.scrollExtentThreshold].
-const defaultScrollExtentThreshold = 400.0;
-
 /// Default value to [InfiniteList.debounceDuration].
 const defaultDebounceDuration = Duration(milliseconds: 100);

--- a/lib/src/infinite_list.dart
+++ b/lib/src/infinite_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:very_good_infinite_list/src/defaults.dart';
 import 'package:very_good_infinite_list/src/sliver_infinite_list.dart';
 
@@ -28,7 +29,7 @@ class InfiniteList extends StatelessWidget {
     this.scrollController,
     this.scrollDirection = Axis.vertical,
     this.physics,
-    this.scrollExtentThreshold = defaultScrollExtentThreshold,
+    this.cacheExtent,
     this.debounceDuration = defaultDebounceDuration,
     this.reverse = false,
     this.isLoading = false,
@@ -39,10 +40,7 @@ class InfiniteList extends StatelessWidget {
     this.loadingBuilder,
     this.errorBuilder,
     this.separatorBuilder,
-  }) : assert(
-          scrollExtentThreshold >= 0.0,
-          'scrollExtentThreshold must be greater than or equal to 0.0',
-        );
+  });
 
   /// {@template scroll_controller}
   /// An optional [ScrollController] to be used by the internal [ScrollView].
@@ -59,22 +57,6 @@ class InfiniteList extends StatelessWidget {
   /// An optional [ScrollPhysics] to be used by the internal [ScrollView].
   /// {@endtemplate}
   final ScrollPhysics? physics;
-
-  /// {@template scroll_extent_threshold}
-  /// The offset, in pixels, that the [scrollController] must be scrolled over
-  /// to trigger [onFetchData].
-  ///
-  /// This is useful for fetching data _before_ the user has scrolled all the
-  /// way to the end of the list, so the fetching mechanism is more well hidden.
-  ///
-  /// For example, if this is set to `400.0` (the default), [onFetchData] will
-  /// be called when the list is scrolled `400.0` pixels away from the bottom
-  /// (or the top if [reverse] is `true`).
-  ///
-  /// This value must be `0.0` or greater, is set to
-  /// [defaultScrollExtentThreshold] by default and cannot be `null`.
-  /// {@endtemplate}
-  final double scrollExtentThreshold;
 
   /// {@template debounce_duration}
   /// The duration with which calls to [onFetchData] will be debounced.
@@ -135,13 +117,16 @@ class InfiniteList extends StatelessWidget {
   /// In normal operation, this method should trigger new data to be fetched and
   /// [isLoading] to be set to `true`.
   ///
-  /// Exactly when this is called depends on the [scrollExtentThreshold].
+  /// Exactly when this is called depends on the [cacheExtent].
   /// Additionally, every call to this will be debounced by the provided
   /// [debounceDuration].
   ///
   /// Is required and cannot be `null`.
   /// {@endtemplate}
   final VoidCallback onFetchData;
+
+  /// See [RenderViewportBase.cacheExtent]
+  final double? cacheExtent;
 
   /// {@template padding}
   /// The amount of space by which to inset the list of items.
@@ -193,9 +178,10 @@ class InfiniteList extends StatelessWidget {
   Widget build(BuildContext context) {
     return CustomScrollView(
       scrollDirection: scrollDirection,
+      reverse: reverse,
       controller: scrollController,
       physics: physics,
-      reverse: reverse,
+      cacheExtent: cacheExtent,
       slivers: [
         _ContextualSliverPadding(
           padding: padding,
@@ -204,7 +190,6 @@ class InfiniteList extends StatelessWidget {
             itemCount: itemCount,
             onFetchData: onFetchData,
             itemBuilder: itemBuilder,
-            scrollExtentThreshold: scrollExtentThreshold,
             debounceDuration: debounceDuration,
             isLoading: isLoading,
             hasError: hasError,

--- a/lib/src/sliver_infinite_list.dart
+++ b/lib/src/sliver_infinite_list.dart
@@ -72,18 +72,14 @@ class _SliverInfiniteListState extends State<SliverInfiniteList> {
   void initState() {
     super.initState();
     debounce = CallbackDebouncer(widget.debounceDuration);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      attemptFetch();
-    });
+    attemptFetch();
   }
 
   @override
   void didUpdateWidget(SliverInfiniteList oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.hasReachedMax != oldWidget.hasReachedMax) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        attemptFetch();
-      });
+    if (!widget.hasReachedMax && oldWidget.hasReachedMax) {
+      attemptFetch();
     }
   }
 
@@ -95,16 +91,16 @@ class _SliverInfiniteListState extends State<SliverInfiniteList> {
 
   void attemptFetch() {
     if (!widget.hasReachedMax && !widget.isLoading && !widget.hasError) {
-      debounce(widget.onFetchData);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        debounce(widget.onFetchData);
+      });
     }
   }
 
   void onBuiltLast(int lastItemIndex) {
     if (_lastFetchedIndex != lastItemIndex) {
       _lastFetchedIndex = lastItemIndex;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        attemptFetch();
-      });
+      attemptFetch();
     }
   }
 

--- a/lib/src/sliver_infinite_list.dart
+++ b/lib/src/sliver_infinite_list.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:very_good_infinite_list/src/callback_debouncer.dart';
 import 'package:very_good_infinite_list/src/defaults.dart';
@@ -10,14 +9,13 @@ import 'package:very_good_infinite_list/src/infinite_list.dart';
 ///
 /// As a infinite list, it is supposed to be the last sliver in the current
 /// [ScrollView]. Otherwise, re-fetching data will have an unintuitive behavior.
-class SliverInfiniteList extends StatelessWidget {
+class SliverInfiniteList extends StatefulWidget {
   /// Constructs a [SliverInfiniteList].
   const SliverInfiniteList({
     super.key,
     required this.itemCount,
     required this.onFetchData,
     required this.itemBuilder,
-    this.scrollExtentThreshold = defaultScrollExtentThreshold,
     this.debounceDuration = defaultDebounceDuration,
     this.isLoading = false,
     this.hasError = false,
@@ -26,13 +24,7 @@ class SliverInfiniteList extends StatelessWidget {
     this.errorBuilder,
     this.separatorBuilder,
     this.emptyBuilder,
-  }) : assert(
-          scrollExtentThreshold >= 0.0,
-          'scrollExtentThreshold must be greater than or equal to 0.0',
-        );
-
-  /// {@macro scroll_extent_threshold}
-  final double scrollExtentThreshold;
+  });
 
   /// {@macro debounce_duration}
   final Duration debounceDuration;
@@ -68,83 +60,13 @@ class SliverInfiniteList extends StatelessWidget {
   final ItemBuilder itemBuilder;
 
   @override
-  Widget build(BuildContext context) {
-    return SliverLayoutBuilder(
-      builder: (context, constraints) {
-        return _SliverInfiniteListInternal(
-          itemCount: itemCount,
-          onFetchData: onFetchData,
-          itemBuilder: itemBuilder,
-          scrollExtentThreshold: scrollExtentThreshold,
-          debounceDuration: debounceDuration,
-          isLoading: isLoading,
-          hasError: hasError,
-          hasReachedMax: hasReachedMax,
-          precedingScrollExtent: constraints.precedingScrollExtent,
-          loadingBuilder: loadingBuilder,
-          errorBuilder: errorBuilder,
-          separatorBuilder: separatorBuilder,
-          emptyBuilder: emptyBuilder,
-        );
-      },
-    );
-  }
+  State<SliverInfiniteList> createState() => _SliverInfiniteListState();
 }
 
-class _SliverInfiniteListInternal extends StatefulWidget {
-  const _SliverInfiniteListInternal({
-    required this.itemCount,
-    required this.onFetchData,
-    required this.itemBuilder,
-    required this.scrollExtentThreshold,
-    required this.debounceDuration,
-    required this.isLoading,
-    required this.hasError,
-    required this.hasReachedMax,
-    required this.precedingScrollExtent,
-    this.loadingBuilder,
-    this.errorBuilder,
-    this.separatorBuilder,
-    this.emptyBuilder,
-  });
-
-  final double scrollExtentThreshold;
-
-  final Duration debounceDuration;
-
-  final int itemCount;
-
-  final bool isLoading;
-
-  final bool hasError;
-
-  final bool hasReachedMax;
-
-  final VoidCallback onFetchData;
-
-  /// See [SliverConstraints.precedingScrollExtent]
-  final double precedingScrollExtent;
-
-  final WidgetBuilder? loadingBuilder;
-
-  final WidgetBuilder? errorBuilder;
-
-  final WidgetBuilder? separatorBuilder;
-
-  final ItemBuilder itemBuilder;
-
-  final WidgetBuilder? emptyBuilder;
-
-  @override
-  State<_SliverInfiniteListInternal> createState() =>
-      _SliverInfiniteListInternalState();
-}
-
-class _SliverInfiniteListInternalState
-    extends State<_SliverInfiniteListInternal> {
+class _SliverInfiniteListState extends State<SliverInfiniteList> {
   late final CallbackDebouncer debounce;
 
-  ScrollPosition? scrollPosition;
+  int? _lastFetchedIndex;
 
   @override
   void initState() {
@@ -156,19 +78,9 @@ class _SliverInfiniteListInternalState
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-
-    detachFromPosition();
-    scrollPosition = Scrollable.of(context)?.position;
-    attachToPosition();
-  }
-
-  @override
-  void didUpdateWidget(_SliverInfiniteListInternal oldWidget) {
+  void didUpdateWidget(SliverInfiniteList oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.itemCount != oldWidget.itemCount ||
-        widget.hasReachedMax != oldWidget.hasReachedMax) {
+    if (widget.hasReachedMax != oldWidget.hasReachedMax) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         attemptFetch();
       });
@@ -179,43 +91,21 @@ class _SliverInfiniteListInternalState
   void dispose() {
     super.dispose();
     debounce.dispose();
-    detachFromPosition();
-  }
-
-  void attachToPosition() {
-    scrollPosition?.addListener(attemptFetch);
-  }
-
-  void detachFromPosition() {
-    scrollPosition?.removeListener(attemptFetch);
   }
 
   void attemptFetch() {
-    if (isAtEnd &&
-        !widget.hasReachedMax &&
-        !widget.isLoading &&
-        !widget.hasError) {
+    if (!widget.hasReachedMax && !widget.isLoading && !widget.hasError) {
       debounce(widget.onFetchData);
     }
   }
 
-  bool get isAtEnd {
-    if (widget.itemCount == 0) {
-      return true;
+  void onBuiltLast(int lastItemIndex) {
+    if (_lastFetchedIndex != lastItemIndex) {
+      _lastFetchedIndex = lastItemIndex;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        attemptFetch();
+      });
     }
-
-    final scrollPosition = this.scrollPosition;
-    if (scrollPosition == null) {
-      return false;
-    }
-
-    // This considers the end of the scrollable content as the
-    // position to trigger a data fetch. It may cause unintuitive behaviors
-    // when there is any sliver after this one.
-    final maxScroll = scrollPosition.maxScrollExtent;
-
-    final currentScroll = scrollPosition.pixels - widget.precedingScrollExtent;
-    return currentScroll >= (maxScroll - widget.scrollExtentThreshold);
   }
 
   WidgetBuilder get loadingBuilder =>
@@ -244,6 +134,9 @@ class _SliverInfiniteListInternalState
       delegate: SliverChildBuilderDelegate(
         childCount: effectiveItemCount,
         (context, index) {
+          if (index == lastItemIndex) {
+            onBuiltLast(lastItemIndex);
+          }
           if (index == lastItemIndex && showBottomWidget) {
             if (widget.hasError) {
               return errorBuilder(context);

--- a/test/sliver_infinite_list_test.dart
+++ b/test/sliver_infinite_list_test.dart
@@ -3,13 +3,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:very_good_infinite_list/src/sliver_infinite_list.dart';
 
 extension on WidgetTester {
-  Future<void> pumpSlivers(List<Widget> slivers) async {
+  Future<void> pumpSlivers(
+    List<Widget> slivers, {
+    double? cacheExtent,
+  }) async {
     await pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: SizedBox(
             height: 500,
             child: CustomScrollView(
+              cacheExtent: cacheExtent,
               slivers: slivers,
             ),
           ),
@@ -28,16 +32,16 @@ void main() {
         var onFetchDataCalls = 0;
 
         await tester.pumpSlivers(
+          cacheExtent: 0,
           [
             StatefulBuilder(
               builder: (context, setState) {
                 return SliverInfiniteList(
                   itemCount: itemCount,
                   debounceDuration: Duration.zero,
-                  hasReachedMax: itemCount == 12,
                   onFetchData: () {
                     setState(() {
-                      itemCount += 3;
+                      itemCount += 8;
                       onFetchDataCalls++;
                     });
                   },
@@ -51,15 +55,15 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(onFetchDataCalls, equals(4));
+        expect(onFetchDataCalls, equals(5));
       });
     });
     group('consider preceding slivers', () {
       testWidgets('on mount', (tester) async {
         var itemCount = 0;
         var onFetchDataCalls = 0;
-
         await tester.pumpSlivers(
+          cacheExtent: 0,
           [
             const SliverAppBar(
               expandedHeight: 500,
@@ -73,10 +77,9 @@ void main() {
                 return SliverInfiniteList(
                   itemCount: itemCount,
                   debounceDuration: Duration.zero,
-                  hasReachedMax: itemCount == 12,
                   onFetchData: () {
                     setState(() {
-                      itemCount += 3;
+                      itemCount += 8;
                       onFetchDataCalls++;
                     });
                   },


### PR DESCRIPTION
## Description

Fixes: https://github.com/VeryGoodOpenSource/very_good_infinite_list/issues/41#issuecomment-1278097815

⚠️ Breaking ⚠️

Ad a breaking change, this delegates the re-fetching trigger from our custom code (reliant on ScrollPsotion) to the SliverList (SlverCosntraints reliant). 

This will trigger the re-fetching once the last item in the list is built.  That should happen when the viewport hits the bottom of the scrollable [cache area](https://api.flutter.dev/flutter/widgets/ScrollView/cacheExtent.html).

Now that we rely on the cache area, we don't need `scrollExtentThreshold` nor the SliverInfiniteList needs to be the last sliver on a CustomScrollView. 

Instead, the user can pass `cacheExtent` to the InfiniteList to customize the cache area of the internal ScrollView. SliverInfiniteList users can pass that to their own `CustomScrollView`.

The cache area is not exactly the same as `cacheExtent` since it is applied to both edges of the sliver, not only the trailing one. 

### Breaking changes:

Public member `defaultScrollExtentThreshold` was removed. Any tests and implementations that use it will break.

Public members `InfiniteList.scrollExtentThreshold` and `SliverInfiniteList.scrollExtentThreshold` were removed.  Any implementation that specified these values will break.

Default behavior for `InfiniteList.scrollExtentThreshold` and `SliverInfiniteList.scrollExtentThreshold` was to apply `defaultScrollExtentThreshold`, which was equal to 400 pixels. Now that we rely on cacheExtent, the default value resorts to the frameworks `RenderAbstractViewport.defaultCacheExtent`. Which is equal to 250 pixels.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
