### PR TITLE
chore: attempt updates to publish workflow

### DIFF
--- a/.github/workflows/pub_publish.yaml
+++ b/.github/workflows/pub_publish.yaml
@@ -8,14 +8,18 @@ on:
 jobs:
   publish:
     permissions:
-      id-token: write # This is required for requesting the JWT
+      id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
+      - name: 🎯 Setup Dart
+        uses: dart-lang/setup-dart@v1
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
       - name: 📦 Install Dependencies
         run: flutter pub get
+      - name: 🌵 Dry Run
+        run: dart pub publish --dry-run
       - name: 📢 Publish
         run: dart pub publish --force


### PR DESCRIPTION
## Status

**READY**

## Description

Attempting to fix #74.

Even though this is a Flutter package, I think the Dart setup step is still needed based on this documentation

> The workflow authenticates to pub.dev using a temporary [GitHub-signed OIDC token](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect), the token is created and configured in the dart-lang/setup-dart step.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
