### PR TITLE
feat: expose shrinkWrap of CustomScrollView

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ InfiniteList<String>(
   // Is set to `false` by default.
   reverse: false,
 
+  // Indicates if the extent of the ScrollView in the scrollDirection
+  // should be determined by the contents being viewed.
+  //
+  // Is set to `false` by default.
+  shrinkWrap: false,
+
   // The duration with which calls to [onFetchData] will be debounced.
   //
   // Is set to a duration of 100 milliseconds by default.

--- a/lib/src/infinite_list.dart
+++ b/lib/src/infinite_list.dart
@@ -32,6 +32,7 @@ class InfiniteList extends StatelessWidget {
     this.cacheExtent,
     this.debounceDuration = defaultDebounceDuration,
     this.reverse = false,
+    this.shrinkWrap = false,
     this.isLoading = false,
     this.hasError = false,
     this.hasReachedMax = false,
@@ -76,6 +77,14 @@ class InfiniteList extends StatelessWidget {
   /// will be rendered from bottom to top.
   /// {@endtemplate}
   final bool reverse;
+
+  /// Indicates if the extent of the [ScrollView] in the [scrollDirection]
+  /// should be determined by the contents being viewed.
+  ///
+  /// See also:
+  ///
+  /// * [CustomScrollView.shrinkWrap], for more details about this flag.
+  final bool shrinkWrap;
 
   /// {@template item_count}
   /// The amount of items that need to be rendered by the [itemBuilder].
@@ -207,6 +216,7 @@ class InfiniteList extends StatelessWidget {
     return CustomScrollView(
       scrollDirection: scrollDirection,
       reverse: reverse,
+      shrinkWrap: shrinkWrap,
       controller: scrollController,
       physics: physics,
       cacheExtent: cacheExtent,

--- a/test/infinite_list_test.dart
+++ b/test/infinite_list_test.dart
@@ -406,6 +406,36 @@ void main() {
             tester.widget<CustomScrollView>(find.byType(CustomScrollView));
         expect(customScrollView.reverse, reverse);
       });
+
+      testWidgets('shrinkWrap', (tester) async {
+        const shrinkWrap = true;
+        await tester.pumpApp(
+          InfiniteList(
+            itemCount: 10,
+            onFetchData: emptyCallback,
+            itemBuilder: (_, i) => Text('$i'),
+            shrinkWrap: shrinkWrap,
+          ),
+        );
+
+        final customScrollView =
+            tester.widget<CustomScrollView>(find.byType(CustomScrollView));
+        expect(customScrollView.shrinkWrap, shrinkWrap);
+      });
+
+      testWidgets('shrinkWrap defaults to false', (tester) async {
+        await tester.pumpApp(
+          InfiniteList(
+            itemCount: 10,
+            onFetchData: emptyCallback,
+            itemBuilder: (_, i) => Text('$i'),
+          ),
+        );
+
+        final customScrollView =
+            tester.widget<CustomScrollView>(find.byType(CustomScrollView));
+        expect(customScrollView.shrinkWrap, false);
+      });
     });
 
     group('centralized properties', () {


### PR DESCRIPTION
## Status

**READY**

## Description

This PR exposes the shrinkWrap parameter of the CustomScrollView used internally in VeryGoodInfiniteList, allowing better control over the list’s layout behavior.

This work is based on the initial contribution from [#71](https://github.com/VeryGoodOpenSource/very_good_infinite_list/pull/71) by @limcheekin, which appears inactive.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
